### PR TITLE
README: Fix 'Quick Example' to be runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,19 +536,19 @@ function MoveSystem:update(dt)
 end
 
 
-local DrawSystem = Concord.System({Position, Drawable})
+local DrawSystem = Concord.system({Position, Drawable})
 
 function DrawSystem:draw()
     for _, e in ipairs(self.pool) do
         local position = e[Position]
-        
+
         love.graphics.circle("fill", position.x, position.y, 5)
     end
 end
 
 
 -- Create the World
-local world = World()
+local world = Concord.world()
 
 -- Add the Systems
 world:addSystems(MoveSystem, DrawSystem)
@@ -571,11 +571,11 @@ local entity_3 = Concord.entity(world)
 
 -- Emit the events
 function love.update(dt)
-    world:emit(dt)
+    world:emit("update", dt)
 end
 
 function love.draw()
-    world:draw()
+    world:emit("draw")
 end
 ```
 


### PR DESCRIPTION
Hey!

Was having a tinker with Concord, and the "Quick Example" in the README wasn't runnable just by copy-and-pasting it.

I've made the quick edits to fix 'em (I hope they're correct, they _seem_ to work haha), as well as a stray empty line (the whitespace change).