### PR TITLE
Fix error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Concord.component("velocity", function(c, x, y)
     c.y = y or 0
 end)
 
-local Drawable = Concord.component()
+local Drawable = Concord.component("drawable")
 
 
 -- Defining Systems


### PR DESCRIPTION
Quick Example failed to run due to no tag being passed to the Drawable component.