### PR TITLE
Added beforeEmit and afterEmit World callbacks

### DIFF
--- a/concord/world.lua
+++ b/concord/world.lua
@@ -318,7 +318,11 @@ function World:emit(functionName, ...)
 
    self.__emitSDepth = self.__emitSDepth + 1
 
-	local listeners = self.__events[functionName]
+   local listeners = self.__events[functionName]
+
+   if Type.isCallable(self.beforeEmit) then
+      self:beforeEmit(functionName, listeners, ...)
+   end
 
    if listeners then
       for i = 1, #listeners do
@@ -332,6 +336,10 @@ function World:emit(functionName, ...)
             listener.callback(listener.system, ...)
          end
       end
+   end
+
+   if Type.isCallable(self.afterEmit) then
+      self:afterEmit(functionName, listeners, ...)
    end
 
    self.__emitSDepth = self.__emitSDepth - 1

--- a/concord/world.lua
+++ b/concord/world.lua
@@ -324,8 +324,9 @@ function World:emit(functionName, ...)
 
    if not self.__ignoreEmits and Type.isCallable(self.beforeEmit) then
       self.__ignoreEmits = true
-      self:beforeEmit(functionName, listeners, ...)
+      local preventDefaults = self:beforeEmit(functionName, listeners, ...)
       self.__ignoreEmits = false
+      if preventDefaults then return end
    end
 
    if listeners then

--- a/concord/world.lua
+++ b/concord/world.lua
@@ -50,6 +50,8 @@ function World.new()
       __systemLookup = {},
 
       __isWorld = true,
+
+      __ignoreEmits = false
    }, World.__mt)
 
    -- Optimization: We deep copy the World class into our instance of a world.
@@ -320,8 +322,10 @@ function World:emit(functionName, ...)
 
    local listeners = self.__events[functionName]
 
-   if Type.isCallable(self.beforeEmit) then
+   if not self.__ignoreEmits and Type.isCallable(self.beforeEmit) then
+      self.__ignoreEmits = true
       self:beforeEmit(functionName, listeners, ...)
+      self.__ignoreEmits = false
    end
 
    if listeners then
@@ -338,8 +342,10 @@ function World:emit(functionName, ...)
       end
    end
 
-   if Type.isCallable(self.afterEmit) then
+   if not self.__ignoreEmits and Type.isCallable(self.afterEmit) then
+      self.__ignoreEmits = true
       self:afterEmit(functionName, listeners, ...)
+      self.__ignoreEmits = false
    end
 
    self.__emitSDepth = self.__emitSDepth - 1


### PR DESCRIPTION
For #52 

Sample usage:
```lua
local Concord = require("concord")
local world

local Foo = Concord.system()
function Foo:greet(name) print("hi " .. name) end

local Bar = Concord.system()
function Bar:greet(name) print("hello " .. name) end
function Bar:bye(name) print("bye " .. name) world:emit("test", name) end
function Bar:test(name) print("test " .. name) end

world = Concord.world()
  :addSystem(Foo)
  :addSystem(Bar)

world.beforeEmit = function(world, event, listeners, ...)
  print(world, event, listeners and #listeners, ...)
  world:emit("bye", "flam")
end

world.afterEmit = function(world, event, listeners, ...)
  print(world, event, listeners and #listeners, ...)
  world:emit("greet", "flam")
end

world:emit("greet", "flam")
--beforeEmit = table, "greet", 2, table, "flam"
--hi flam
--hello flam
--afterEmit = table, "greet", 2, table, "flam"

world:emit("bye", "flam")
--beforeEmit = table, "bye", 1, table, "flam"
--bye flam
--afterEmit = table, "bye", 1, table, "flam"
```